### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server that provides file deletion capabilities. This server allows AI assistants to safely delete files when needed, with support for both relative and absolute paths.
 
+<a href="https://glama.ai/mcp/servers/dpxui4mdbx"><img width="380" height="200" src="https://glama.ai/mcp/servers/dpxui4mdbx/badge" alt="MCP-Delete MCP server" /></a>
+
 ## Features
 
 - Delete files using relative or absolute paths


### PR DESCRIPTION
This PR adds a badge for the MCP-Delete server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/dpxui4mdbx"><img width="380" height="200" src="https://glama.ai/mcp/servers/dpxui4mdbx/badge" alt="MCP-Delete MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.