### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # @qpd-v/mcp-delete
+[![smithery badge](https://smithery.ai/badge/@qpd-v/mcp-delete)](https://smithery.ai/server/@qpd-v/mcp-delete)
 
 A Model Context Protocol (MCP) server that provides file deletion capabilities. This server allows AI assistants to safely delete files when needed, with support for both relative and absolute paths.
 
@@ -20,6 +21,15 @@ A Model Context Protocol (MCP) server that provides file deletion capabilities. 
 
 ## Installation
 
+### Installing via Smithery
+
+To install File Deletion for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@qpd-v/mcp-delete):
+
+```bash
+npx -y @smithery/cli install @qpd-v/mcp-delete --client claude
+```
+
+### Manual Installation
 ```bash
 npx @qpd-v/mcp-delete
 ```


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install File Deletion for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@qpd-v/mcp-delete

Let me know if any tweaks have to be made!